### PR TITLE
chore(build): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@actions/cache": "^1.0.7",
-				"@actions/core": "^1.4.0",
+				"@actions/core": "^1.10.0",
 				"@actions/exec": "^1.1.0",
 				"@actions/github": "^4.0.0",
 				"@actions/io": "^1.1.1",
@@ -31,9 +31,6 @@
 				"rollup": "^2.55.1",
 				"rollup-plugin-esbuild": "^4.5.0",
 				"rollup-plugin-terser": "^7.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/pkg-size/action?sponsor=1"
 			}
 		},
 		"node_modules/@actions/cache": {
@@ -54,12 +51,31 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
-			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"dev": true,
 			"dependencies": {
-				"@actions/http-client": "^1.0.11"
+				"@actions/http-client": "^2.0.1",
+				"uuid": "^8.3.2"
+			}
+		},
+		"node_modules/@actions/core/node_modules/@actions/http-client": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+			"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+			"dev": true,
+			"dependencies": {
+				"tunnel": "^0.0.6"
+			}
+		},
+		"node_modules/@actions/core/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@actions/exec": {
@@ -5359,12 +5375,30 @@
 			}
 		},
 		"@actions/core": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
-			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"dev": true,
 			"requires": {
-				"@actions/http-client": "^1.0.11"
+				"@actions/http-client": "^2.0.1",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"@actions/http-client": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+					"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+					"dev": true,
+					"requires": {
+						"tunnel": "^0.0.6"
+					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
+				}
 			}
 		},
 		"@actions/exec": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -862,6 +862,30 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
@@ -3393,9 +3417,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -3553,12 +3577,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"node_modules/lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"node_modules/lodash.truncate": {
@@ -4621,9 +4639,9 @@
 			"dev": true
 		},
 		"node_modules/semver-regex": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-			"integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -4705,18 +4723,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/source-map": {
-			"version": "0.8.0-beta.0",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-			"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-			"dev": true,
-			"dependencies": {
-				"whatwg-url": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/source-map-support": {
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4734,32 +4740,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map/node_modules/tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"dependencies": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/source-map/node_modules/webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
-		},
-		"node_modules/source-map/node_modules/whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-			"dev": true,
-			"dependencies": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -5002,14 +4982,14 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-			"integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+			"version": "5.16.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+			"integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
 			"dev": true,
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.8.0-beta.0",
 				"source-map-support": "~0.5.20"
 			},
 			"bin": {
@@ -5103,9 +5083,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -6052,6 +6032,29 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
 			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
 			"dev": true
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/gen-mapping": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/sourcemap-codec": "^1.4.10",
+						"@jridgewell/trace-mapping": "^0.3.9"
+					}
+				}
+			}
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
@@ -7971,9 +7974,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jsonc-eslint-parser": {
@@ -8095,12 +8098,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.truncate": {
@@ -8887,9 +8884,9 @@
 			"dev": true
 		},
 		"semver-regex": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-			"integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
 			"dev": true
 		},
 		"serialize-javascript": {
@@ -8948,43 +8945,6 @@
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
 				"is-fullwidth-code-point": "^3.0.0"
-			}
-		},
-		"source-map": {
-			"version": "0.8.0-beta.0",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-			"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-			"dev": true,
-			"requires": {
-				"whatwg-url": "^7.0.0"
-			},
-			"dependencies": {
-				"tr46": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-					"dev": true,
-					"requires": {
-						"punycode": "^2.1.0"
-					}
-				},
-				"webidl-conversions": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				}
 			}
 		},
 		"source-map-support": {
@@ -9194,14 +9154,14 @@
 			}
 		},
 		"terser": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-			"integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+			"version": "5.16.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+			"integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
 			"dev": true,
 			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.8.0-beta.0",
 				"source-map-support": "~0.5.20"
 			},
 			"dependencies": {
@@ -9276,9 +9236,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@actions/cache": "^1.0.7",
-		"@actions/core": "^1.4.0",
+		"@actions/core": "^1.10.0",
 		"@actions/exec": "^1.1.0",
 		"@actions/github": "^4.0.0",
 		"@actions/io": "^1.1.1",


### PR DESCRIPTION
This PR bumps the `@actions/core` package to version `1.10.0` (current latest).

This is needed because of the imminent deprecation of the `set-output` command [described here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands). According to the linked article from GitHub in [this section](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows), the fix for the SDK consists in updating the version to `1.10.0` or higher.

While doing that, I have also run `npm audit fix` to bump some of the peer dependencies that were vulnerable.